### PR TITLE
QbUtil: consistent orientation + unix support in shader paths

### DIFF
--- a/src/stonevox/Program.java
+++ b/src/stonevox/Program.java
@@ -172,8 +172,8 @@ public class Program
 
 		shader = new Shader();
 
-		shader.vertexshader_path = "/shaders/VertexShader.txt";
-		shader.fragmentshader_path = "/shaders/FragmentShader.txt";
+		shader.vertexshader_path = "shaders/VertexShader.txt";
+		shader.fragmentshader_path = "shaders/FragmentShader.txt";
 		shader.Load();
 		shader.InstallShader();
 		shader.UseShader();

--- a/src/stonevox/util/GetPath.java
+++ b/src/stonevox/util/GetPath.java
@@ -19,7 +19,7 @@ public class GetPath
 			// TODO Auto-generated catch block
 			e1.printStackTrace();
 		}
-		path1 = path1.substring(6);
+		path1 = path1.substring(5);
 
 		String hack = "StoneVox3D-0.0.4.jar";
 

--- a/src/stonevox/util/QbUtil.java
+++ b/src/stonevox/util/QbUtil.java
@@ -147,7 +147,7 @@ public class QbUtil
 								{
 									int x = index % (int) def.size.x;
 									int y = index / (int) def.size.x;
-									def.cubecolor[tz][y][(int) def.size.x - x - 1] = new Color(0, 0, 0, 0);
+									def.cubecolor[tz][y][x] = new Color(0, 0, 0, 0);
 								}
 								break;
 							}
@@ -165,8 +165,7 @@ public class QbUtil
 										int x = index % (int) def.size.x;
 										int y = index / (int) def.size.x;
 										index++;
-										def.cubecolor[tz][y][(int) def.size.x - x - 1] =
-												getColor(r, g, b, a, model.colorFormat);
+										def.cubecolor[tz][y][x] = getColor(r, g, b, a, model.colorFormat);
 									}
 								}
 								else
@@ -174,8 +173,7 @@ public class QbUtil
 									int x = index % (int) def.size.x;
 									int y = index / (int) def.size.x;
 									index++;
-									def.cubecolor[tz][y][(int) def.size.x - x - 1] =
-											getColor(r, g, b, a, model.colorFormat);
+									def.cubecolor[tz][y][x] = getColor(r, g, b, a, model.colorFormat);
 								}
 							}
 						}


### PR DESCRIPTION
This PR changes the code for loading compressed `.qb` files to make it consistent with the model orientation changes introduced in 94dce53
